### PR TITLE
[DXFC-258]  Changing the order of the candle symbol's attributes breaks the reading of the candledata

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,3 +1,6 @@
+Version 8.4.0
+* [DXFC-258] Fixed a bug with the impossibility of receiving candledata when changing the order of candle symbol attributes 
+
 Version 8.3.0
 * [DXFC-254] The amount of memory used to store the symbols required for a subscription has been reduced by several times.
 * [DXFC-238] Added the ability to set PriceLevelBook symbol or orders sources. Added the new methods:
@@ -21,7 +24,7 @@ Version 8.3.0
   - CreateOrderViewSubscription, OrderViewSubscription
   - DXFeedLastingEventsCollector, LastingEventsCollector, DXFeedSnapshotCollector
   
-  Please use NativeConnection, NativeSubscription classes and their methods:
+  Please use NativeConnection, NativeSubscription classes and their methods.
 
 Version 8.2.0
 * [DXFC-220] Added the ability to retrieve events starting from a specific date and ending with a specific date.  

--- a/dxf_native/src/CandleDataConnection.cs
+++ b/dxf_native/src/CandleDataConnection.cs
@@ -134,8 +134,15 @@ namespace com.dxfeed.native
                         {
                             result = await dataProvider.Run(fileToWriteTo, symbols, cancellationToken);
                         }
-                        
-                        File.Delete(fileToWriteTo);
+
+                        try
+                        {
+                            File.Delete(fileToWriteTo);
+                        }
+                        catch (Exception)
+                        {
+                            // ignored
+                        }
                     }
                 }
                 

--- a/dxf_native/src/NativeSnapshotSubscription.cs
+++ b/dxf_native/src/NativeSnapshotSubscription.cs
@@ -277,20 +277,7 @@ namespace com.dxfeed.native
             if (eventType != EventType.None && eventType != EventType.Candle)
                 throw new InvalidOperationException("It is allowed only for Candle subscription");
 
-            IntPtr candleAttributesPtr;
-            
-            C.CheckOk(C.Instance.dxf_create_candle_symbol_attributes(symbol.BaseSymbol,
-                symbol.ExchangeCode, symbol.PeriodValue, symbol.PeriodId, symbol.PriceId,
-                symbol.SessionId, symbol.AlignmentId, symbol.PriceLevel, out candleAttributesPtr));
-
-            try
-            {
-                C.CheckOk(C.Instance.dxf_create_candle_snapshot(connectionPtr, candleAttributesPtr, time, out snapshotPtr));
-            }
-            finally
-            {
-                C.CheckOk(C.Instance.dxf_delete_candle_symbol_attributes(candleAttributesPtr));
-            }
+            C.CheckOk(C.Instance.dxf_create_snapshot(connectionPtr, EventTypeUtil.GetEventId(eventType), symbol.ToString(), null, time, out snapshotPtr));
 
             try
             {

--- a/dxf_native/src/NativeSubscription.cs
+++ b/dxf_native/src/NativeSubscription.cs
@@ -392,19 +392,7 @@ namespace com.dxfeed.native
             if (symbol == null)
                 throw new ArgumentException("Invalid symbol parameter.");
             
-            IntPtr candleAttributesPtr;
-            
-            C.CheckOk(C.Instance.dxf_create_candle_symbol_attributes(symbol.BaseSymbol,
-                symbol.ExchangeCode, symbol.PeriodValue, symbol.PeriodId, symbol.PriceId,
-                symbol.SessionId, symbol.AlignmentId, symbol.PriceLevel, out candleAttributesPtr));
-            try
-            {
-                C.CheckOk(C.Instance.dxf_add_candle_symbol(subscriptionPtr, candleAttributesPtr));
-            }
-            finally
-            {
-                C.CheckOk(C.Instance.dxf_delete_candle_symbol_attributes(candleAttributesPtr));
-            }
+            C.CheckOk(C.Instance.dxf_add_symbol(subscriptionPtr, symbol.ToString()));
         }
 
         /// <summary>


### PR DESCRIPTION
Changing the order of the candle symbol's attributes breaks the reading of the candledata